### PR TITLE
use ruby 3.1 for website workflow

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.1'
           bundler-cache: true
 
       - name: Set up Python


### PR DESCRIPTION
Website build is failing, due to the ruby version being too old for the tools that are loaded by later steps in the process.

This is an attempt to fix that problem, by bumping up the ruby version in the gh-actions workflow. 