### PR TITLE
Update launch.json in 13-ides.md

### DIFF
--- a/_episodes/13-ides.md
+++ b/_episodes/13-ides.md
@@ -424,21 +424,21 @@ with a configuration for just python files
     "configurations": [
         {
             "name": "Catchment-analysis: Rain",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "args" : [ "data/rain_data_2015-12.csv" ],
             "module": "catchment-analysis",
             "console": "integratedTerminal",
-            "justMyCode": True
+            "justMyCode": true
         },
         {
             "name": "Catchment-analysis: River",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "args" : [ "data/river_data_2015-12.csv" ],
             "module": "catchment-analysis",
             "console": "integratedTerminal",
-            "justMyCode": True
+            "justMyCode": true
         }
     ]
 }


### PR DESCRIPTION
VSCode is complaining about a couple of things for me:

* It seems that it likes `true` not `True` for bools.
* Type "python" is reported to be depricated. This warning goes away with "debugpy". This change fixes both. 

Notibly, the debugging seems to work without issues without the change, so not critical ahead of next week.

